### PR TITLE
Upgrade bookshelf

### DIFF
--- a/lib/bookshelf-slug.js
+++ b/lib/bookshelf-slug.js
@@ -37,11 +37,10 @@ module.exports = function(bookshelf, settings) {
       let idAttribute = this.idAttribute
       let column = this.__slug.column;
       this.__transacting = options && options.transacting;
-
       if(!model.isNew()) {
         let changed = false;
         for(let idx in fields) {
-          if(attrs.hasOwnProperty(fields[idx])) {
+          if(model.hasChanged(fields[idx])) {
             changed = true;
           }
         }

--- a/lib/bookshelf-slug.js
+++ b/lib/bookshelf-slug.js
@@ -34,7 +34,6 @@ module.exports = function(bookshelf, settings) {
     __start: function(model, attrs, options) {
       let fields = this.__slug.items;
       let idAttribute = this.idAttribute
-      let column = this.__slug.column;
       this.__transacting = options && options.transacting;
       if(!model.isNew()) {
         let changed = false;

--- a/lib/bookshelf-slug.js
+++ b/lib/bookshelf-slug.js
@@ -1,6 +1,5 @@
 'use strict';
 let slug = require('slug');
-let Promise = require('bluebird');
 
 module.exports = function(bookshelf, settings) {
   let Model = bookshelf.Model;
@@ -29,7 +28,7 @@ module.exports = function(bookshelf, settings) {
         }
         this.__slug = this.slug;
       }
-      this.on('saving', Promise.method(this.__start));
+      this.on('saving', this.__start);
     },
 
     __start: function(model, attrs, options) {
@@ -44,18 +43,21 @@ module.exports = function(bookshelf, settings) {
             changed = true;
           }
         }
-        if(!changed) return Promise.resolve();
+        if(!changed) {
+          return null;
+        }
+
         return this.constructor.forge({[idAttribute]: model.get(idAttribute)})
           .fetch({ transacting: this.__transacting })
           .then(s => {
             let changedValues = Object.assign({}, s ? s.toJSON() : {}, attrs);
             let slugValue = this.__generateSlug(changedValues);
-            return Promise.resolve().then(_ => this.__beginSlug(slugValue));
+
+            return this.__beginSlug(slugValue);
           });
       }
 
-      let slugValue = this.__generateSlug();
-      return Promise.resolve().then(_ => this.__beginSlug(slugValue));
+      return this.__beginSlug(this.__generateSlug());
     },
 
     __generateSlug: function(changed) {
@@ -69,46 +71,36 @@ module.exports = function(bookshelf, settings) {
     },
 
     __beginSlug: function(value) {
-      return Promise.resolve()
-        .then(_ => {
-          return this.__checkSlug(value)
-            .then(isUnique => {
-                if(isUnique) {
-                  return this.set(this.__slug.column, value);
-                }
-                return this.__incrementSlug(value);
-            });
-        })
+      return this.__checkSlug(value)
+        .then(isUnique => {
+            if(isUnique) {
+              return this.set(this.__slug.column, value);
+            }
+            return this.__incrementSlug(value);
+        });
     },
 
     __incrementSlug: function(value) {
       var inc = (newSlug, count) => {
         newSlug = newSlug + '-' + Date.now() +'-'+ count;
-        return Promise.resolve()
-          .then(_ => {
-            return this.__checkSlug(newSlug, this.__slug.column)
-              .then(isUnique => {
-                if(isUnique) {
-                  return this.set(this.__slug.column, newSlug);
-                }
-                return inc(newSlug, count + 1);
-              })
-          })
+        return this.__checkSlug(newSlug, this.__slug.column)
+          .then(isUnique => {
+            if(isUnique) {
+              return this.set(this.__slug.column, newSlug);
+            }
+            return inc(newSlug, count + 1);
+          });
       }
-      return Promise.resolve()
-        .then(_ => inc(value, ~~(Math.random() * 6500) + 1000))
+      return inc(value, ~~(Math.random() * 6500) + 1000);
     },
 
     __checkSlug: function(slugToCheck) {
-      return Promise.resolve()
-        .then(() => {
-          return this.constructor.forge()
-           .where(this.__slug.column, slugToCheck)
-           .fetch({ transacting: this.__transacting })
-           .then(entity => {
-             return Promise.resolve(entity === null)
-           });
-        })
+      return this.constructor.forge()
+       .where(this.__slug.column, slugToCheck)
+       .fetch({ transacting: this.__transacting })
+       .then(entity => {
+         return entity === null;
+       });
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "oscar druiventak",
   "license": "MIT",
   "devDependencies": {
+    "bluebird": "^3.4.1",
     "bookshelf": "^1.0.0",
     "chai": "^4.1.2",
     "knex": "^0.19.2",
@@ -33,7 +34,6 @@
     "sqlite3": "^4.0.2"
   },
   "dependencies": {
-    "bluebird": "^3.4.1",
     "slug": "^0.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   },
   "dependencies": {
     "slug": "^0.9.1"
+  },
+  "peerDependencies": {
+    "bookshelf": ">= 1.0.0 < 1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "author": "oscar druiventak",
   "license": "MIT",
   "devDependencies": {
-    "bookshelf": "^0.13.3",
+    "bookshelf": "^1.0.0",
     "chai": "^4.1.2",
-    "knex": "^0.15.2",
+    "knex": "^0.19.2",
     "mocha": "^5.2.0",
     "sqlite3": "^4.0.2"
   },

--- a/test/database/index.js
+++ b/test/database/index.js
@@ -3,7 +3,6 @@ let config = require('./knexfile');
 let knex = require('knex')(config);
 let bookshelf = require('bookshelf')(knex);
 
-bookshelf.plugin('registry');
 bookshelf.plugin(require('../../'));
 
 module.exports = {

--- a/test/database/migrations/20160817224907_post.js
+++ b/test/database/migrations/20160817224907_post.js
@@ -1,4 +1,4 @@
-exports.up = function(knex, Promise) {
+exports.up = function(knex) {
   return knex.schema.createTable('post', function(table) {
     table.increments();
     table.integer('user_id').references('user.id').notNullable();
@@ -11,6 +11,6 @@ exports.up = function(knex, Promise) {
   });
 };
 
-exports.down = function(knex, Promise) {
+exports.down = function(knex) {
   return knex.schema.dropTable('post');
 };

--- a/test/database/migrations/20160818223913_user.js
+++ b/test/database/migrations/20160818223913_user.js
@@ -1,4 +1,4 @@
-exports.up = function(knex, Promise) {
+exports.up = function(knex) {
   return knex.schema.createTable('user', function(table) {
     table.increments();
     table.string('firstName').notNullable();
@@ -9,6 +9,6 @@ exports.up = function(knex, Promise) {
   });
 };
 
-exports.down = function(knex, Promise) {
+exports.down = function(knex) {
   return knex.schema.dropTable('user');
 };

--- a/test/database/migrations/20200612000824_article.js
+++ b/test/database/migrations/20200612000824_article.js
@@ -1,0 +1,11 @@
+exports.up = function(knex) {
+  return knex.schema.createTable('articles', function(table) {
+    table.increments('id').primary();
+    table.string('title').notNullable();
+    table.string('slug').notNullable().unique();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.dropTable('articles');
+};

--- a/test/database/models/Article.js
+++ b/test/database/models/Article.js
@@ -1,0 +1,8 @@
+'use strict';
+let bookshelf = require('../').bookshelf;
+
+module.exports = bookshelf.model('Article', {
+  tableName: 'articles',
+  requireFetch: false,
+  slug: ['title'],
+});

--- a/test/database/models/Post.js
+++ b/test/database/models/Post.js
@@ -4,6 +4,7 @@ let bookshelf = require('../').bookshelf;
 
 module.exports = bookshelf.model('Post', {
   tableName: 'post',
+  requireFetch: false,
   slug: ['title', 'description'],
   user: function() {
     return this.belongsTo('User');

--- a/test/database/models/User.js
+++ b/test/database/models/User.js
@@ -4,6 +4,7 @@ require('./Post.js');
 
 module.exports = bookshelf.model('User', {
   tableName: 'user',
+  requireFetch: false,
   slug: {
     column: 'uniqueName',
     items: ['firstName', 'lastName', 'nickName']

--- a/test/database/models/index.js
+++ b/test/database/models/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Article = require('./Article');
+const Post = require('./Post');
+const User = require('./User');
+
+module.exports = {
+    Article,
+    Post,
+    User,
+};

--- a/test/database/seeds/user.js
+++ b/test/database/seeds/user.js
@@ -1,18 +1,16 @@
 
-exports.seed = function(knex, Promise) {
+exports.seed = function(knex) {
   // Deletes ALL existing entries
   return knex('user').del()
     .then(function () {
-      return Promise.all([
-        // Inserts seed entries
-        knex('user').insert({
-          id: 1,
-          firstName: 'John',
-          lastName: 'Doe',
-          nickName: 'D',
-          dob: new Date(),
-          uniqueName: 'john-doe-d'
-        }),
-      ]);
+      // Inserts seed entries
+      return knex('user').insert({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        nickName: 'D',
+        dob: new Date(),
+        uniqueName: 'john-doe-d'
+      });
     });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,10 @@
 'use strict';
 let chai = require('chai');
 let expect = chai.expect;
-let Post = require('./database/models/Post');
-let User = require('./database/models/User');
 let knex = require('./database').knex;
 let bookshelf = require('./database').bookshelf;
 let Promise = require('bluebird');
-
+let { Post, User, Article } = require('./database/models');
 
 describe('bookshelf-slug', () => {
   let postId;
@@ -14,11 +12,64 @@ describe('bookshelf-slug', () => {
   before(() => {
     return knex.raw("delete from post")
       .then(() => knex.raw("delete from user"))
+      .then(() => knex.raw("delete from articles"))
   })
 
   after(() => {
     return knex.destroy();
   })
+
+  describe('unique values', () => {
+    beforeEach(async () => await knex.raw("delete from articles"));
+
+    it('will append date if slug is already taken', async () => {
+      await new Article({
+        title: 'The best news',
+        slug: 'the-best-news',
+      }).save();
+
+      expect(await Article.where({ slug: 'the-best-news' }).count()).to.equal(1);
+    });
+
+    it('will append date if slug is already taken', async () => {
+      const first_article = await new Article({
+        title: 'The best news',
+        slug: 'the-best-news',
+      }).save();
+
+      const second_article = await new Article({
+        title: 'The best news',
+        slug: 'the-best-news',
+      }).save();
+
+      expect(await Article.where({ slug: 'the-best-news' }).count()).to.equal(1);
+      expect(second_article.get('slug')).to.not.equal(first_article.get('slug'));
+    });
+
+    it('will not update slug without changes', async () => {
+      const first_article = await new Article({
+        title: 'The best news',
+        slug: 'the-best-news',
+      }).save();
+
+      expect(first_article.get('slug')).to.equal('the-best-news');
+      await first_article.save();
+      expect(first_article.get('slug')).to.equal('the-best-news');
+    });
+
+    it('will update slug when field has changed', async () => {
+      const article = await new Article({
+        title: 'The best news',
+        slug: 'the-best-news',
+      }).save();
+
+      expect(article.get('slug')).to.equal('the-best-news');
+
+      article.set('title', 'The next best news');
+      await article.save();
+      expect(article.get('slug')).to.equal('the-next-best-news');
+    });
+  });
 
   it('should create a post with a unique slug, with default column name: slug', (done) => {
     new Post({


### PR DESCRIPTION
This PR bumps the minimum supported version of Bookshelf to `>1.0.0`.

Reason behind this change is that Bookshelf now have an dict like `Object` with null prototype.
The attrs object looks like this

```
[Object: null prototype]
```

I also took myself the liberty to refactor some internals to better suite Bookshelf promise model. Those commit has been splitted so it's very easy to revert.